### PR TITLE
Port to esp-idf 5.0.4 and some config for VSCode

### DIFF
--- a/esp32/.vscode/c_cpp_properties.json
+++ b/esp32/.vscode/c_cpp_properties.json
@@ -1,0 +1,26 @@
+{
+    "configurations": [
+        {
+            "name": "ESP-IDF",
+            "compilerPath": "${config:idf.toolsPath}/tools/xtensa-esp32s3-elf/esp-2022r1-11.2.0/xtensa-esp32s3-elf/bin/xtensa-esp32s3-elf-gcc",
+            "includePath": [
+                "${config:idf.espIdfPath}/components/**",
+                "${config:idf.espIdfPathWin}/components/**",
+                "${config:idf.espAdfPath}/components/**",
+                "${config:idf.espAdfPathWin}/components/**",
+                "${workspaceFolder}/**"
+            ],
+            "browse": {
+                "path": [
+                    "${config:idf.espIdfPath}/components",
+                    "${config:idf.espIdfPathWin}/components",
+                    "${config:idf.espAdfPath}/components/**",
+                    "${config:idf.espAdfPathWin}/components/**",
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": false
+            }
+        }
+    ],
+    "version": 4
+}

--- a/esp32/.vscode/settings.json
+++ b/esp32/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "idf.adapterTargetName": "esp32s3",
+    "idf.openOcdConfigs": [
+        "board/esp32s3-builtin.cfg"
+    ]
+}

--- a/esp32/components/emu_esp32_bindings/CMakeLists.txt
+++ b/esp32/components/emu_esp32_bindings/CMakeLists.txt
@@ -5,7 +5,7 @@ idf_build_get_property(target IDF_TARGET)
 if (${target} STREQUAL esp32)
 
 idf_component_register(SRCS gfx_esp32.c lcd.c mmap_file_esp32.c audio_esp32.c hiscore.c haptics.c prefs.c
-        REQUIRES emu log spi_flash driver nvs_flash esp_timer
+        REQUIRES emu log spi_flash esp_partition driver nvs_flash esp_timer
         INCLUDE_DIRS "." )
 
 target_compile_options(${COMPONENT_LIB} PRIVATE -DPROJECT_NAME="${CMAKE_PROJECT_NAME}")

--- a/esp32/components/emu_esp32s3_bindings/CMakeLists.txt
+++ b/esp32/components/emu_esp32s3_bindings/CMakeLists.txt
@@ -5,7 +5,7 @@ idf_build_get_property(target IDF_TARGET)
 if (${target} STREQUAL esp32s3)
 
 idf_component_register(SRCS gfx_esp32s3.c lcd.c mmap_file_esp32.c audio_esp32s3.c haptic.c lcdbackboard.c hiscore.c io.c prefs.c mpu6050.c
-        REQUIRES emu log spi_flash driver esp_lcd nvs_flash esp_timer
+        REQUIRES emu log spi_flash esp_partition driver esp_lcd nvs_flash esp_timer
         EMBED_FILES img/loading.rgb img/pf.rgb img/table1.rgb img/table2.rgb img/table3.rgb img/table4.rgb
         INCLUDE_DIRS "." )
 

--- a/esp32/components/emu_esp32s3_bindings/mmap_file_esp32.c
+++ b/esp32/components/emu_esp32s3_bindings/mmap_file_esp32.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <strings.h>
 #include <esp_partition.h>
+#include <spi_flash_mmap.h>
 
 //We map DOS files to partitions. This table contains both the mapping
 //as well as the size of the files.


### PR DESCRIPTION
A few modification to get the code to compile under esp-idf 5.0.4. Please not that stupid me ordered octal-spi module so I cannot test it, but I still wanted to push my work.

Still a few warnings about the use of deprecated MCPWM api, I'll look into it a bit later. It compiles without issue.

Please note that I did not try compiling the ESP32 (not -S3) version.

Also added some vscode config files for a better experience.